### PR TITLE
Added git repository URL to package.json

### DIFF
--- a/gatsby-plugin-cockpit/package.json
+++ b/gatsby-plugin-cockpit/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.39",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-source-plugin", "cockpit"],
   "license": "MIT",
+  "repository": "github:ginetta/ginetta-gatsby-source-plugin",
   "dependencies": {
     "cockpit-sdk": "^0.9.4",
     "gatsby-source-filesystem": "^1.5.15",


### PR DESCRIPTION
Added git repository URL to package.json so that it is easier to identify the corresponding git repository on npmjs.org. This is kind of essential since the package name does not match the repository name on github - despite my best efforts I wasn't able to find the correct repository.